### PR TITLE
fix the exports field

### DIFF
--- a/apps/components-demo/package.json
+++ b/apps/components-demo/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/source-cooperative/components/issues"
   },
   "dependencies": {
-    "@source-cooperative/components": "1.3.1",
+    "@source-cooperative/components": "1.3.2",
     "next": "15.1.6",
     "theme-ui": "0.16.1",
     "@emotion/react": "11.13.3",

--- a/apps/viewers/package.json
+++ b/apps/viewers/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@emotion/react": "11.13.3",
-    "@source-cooperative/components": "1.3.1",
+    "@source-cooperative/components": "1.3.2",
     "next": "15.1.6",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -5,8 +5,10 @@
   "source": "src/index.ts",
   "type": "module",
   "exports": {
-    "types": "./dist/index.d.ts",
-    "import": "./dist/components.esm.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/components.esm.js"
+    }
   },
   "repository": {
     "type": "git",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@source-cooperative/components",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Source Cooperative React Components",
   "source": "src/index.ts",
   "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/components.esm.js"
+      "import": "./dist/components.esm.js",
+      "require": "./dist/components.esm.js"
     }
   },
   "repository": {


### PR DESCRIPTION
issue when dynamically importing components in source.coop:

```
Module not found: Package path . is not exported from package
```